### PR TITLE
Fix typo in `Mint.WebSocket.new()` function doc

### DIFF
--- a/lib/mint/web_socket.ex
+++ b/lib/mint/web_socket.ex
@@ -309,7 +309,7 @@ defmodule Mint.WebSocket do
     Mint.WebSocket.stream(conn, http_reply)
 
   {:ok, conn, websocket} =
-    Mint.WebSocket.new(:ws, conn, ref, status, resp_headers)
+    Mint.WebSocket.new(conn, ref, status, resp_headers)
   ```
   """
   @spec new(


### PR DESCRIPTION
Scheme is passed to `upgrade/5`, not `new/5`.