### PR TITLE
Align WebSocket.Frame.encode/2 spec with WebSocket.encode/2

### DIFF
--- a/lib/mint/web_socket/frame.ex
+++ b/lib/mint/web_socket/frame.ex
@@ -93,7 +93,7 @@ defmodule Mint.WebSocket.Frame do
 
   def new_mask, do: :crypto.strong_rand_bytes(4)
 
-  @spec encode(Mint.WebSocket.t(), Mint.WebSocket.frame()) ::
+  @spec encode(Mint.WebSocket.t(), Mint.WebSocket.shorthand_frame() | Mint.WebSocket.frame()) ::
           {:ok, Mint.WebSocket.t(), bitstring()}
           | {:error, Mint.WebSocket.t(), WebSocketError.t()}
   def encode(websocket, frame) when is_friendly_frame(frame) do


### PR DESCRIPTION
The `Mint.WebSocket.shorthand_frame()` is missing in the `Mint.WebSocket.Frame.encode/2` spec.