### PR TITLE
Add :zlib_controlling_process opt to PerMessageDeflate

### DIFF
--- a/lib/mint/web_socket/per_message_deflate.ex
+++ b/lib/mint/web_socket/per_message_deflate.ex
@@ -14,6 +14,9 @@ defmodule Mint.WebSocket.PerMessageDeflate do
   * `:zlib_memory_level` - (default: `8`) how much memory to allow for use
     during compression. See the `:zlib.deflateInit/6` documentation on the
     `MemLevel` argument.
+  * `:zlib_controlling_process` - (default: `nil`) pass in a specific controlling
+    pid as a list, to prevent `:not_on_controlling_process` errors. See the
+    `:zlib.set_controlling_process/2` documentation `Z` and `Pid` arguments.
   """
 
   require Mint.WebSocket.Frame, as: Frame
@@ -54,6 +57,12 @@ defmodule Mint.WebSocket.PerMessageDeflate do
         Keyword.get(opts, :zlib_memory_level, 8),
         :default
       )
+
+    if Keyword.has_key?(opts, :zlib_controlling_process) do
+      pid_string = Keyword.get(opts, :zlib_controlling_process)
+      :ok = :zlib.set_controlling_process(inflate_zstream, :erlang.list_to_pid(pid_string))
+      :ok = :zlib.set_controlling_process(deflate_zstream, :erlang.list_to_pid(pid_string))
+    end
 
     state = %__MODULE__{
       inflate: inflate_zstream,


### PR DESCRIPTION
The use case here is when using Mint Web Socket with, say, something like NimblePool.

The zlib instantiation happened to me in async initialization. So zlib state snagged a pid from that ephemeral execution. Then, when trying to use the websocket later from the pool, boom, mismatch:

```
** (ErlangError) Erlang error: :not_on_controlling_process
    :zlib.getStash_nif(#Reference<0.329115628.4207804421.73859>)
    :zlib.restore_progress/2
    :zlib.deflate/3
    (mint_web_socket 1.0.2) lib/mint/web_socket/per_message_deflate.ex:143: Mint.WebSocket.PerMessageDeflate.deflate_data/2
    (mint_web_socket 1.0.2) lib/mint/web_socket/per_message_deflate.ex:122: Mint.WebSocket.PerMessageDeflate.encode/2
    (mint_web_socket 1.0.2) lib/mint/web_socket/extension.ex:169: Mint.WebSocket.Extension.encode_all_extensions/3
    (mint_web_socket 1.0.2) lib/mint/web_socket/frame.ex:103: Mint.WebSocket.Frame.encode/2
    iex:1: (file)
```

The change lets us instantiate with a specific pid in the same manner as Mint HTTP. See `init_worker` at:

https://hexdocs.pm/nimble_pool/NimblePool.html#module-http1-based-example

My usage in testing with this patch:

```
      with {:ok, conn} <- Mint.HTTP.connect(:https, uri.host, uri.port),
           {:ok, conn} <- Mint.HTTP.controlling_process(conn, parent),
           {:ok, conn, ref} <-
             Mint.WebSocket.upgrade(:wss, conn, path, [],
               extensions: [
                 {Mint.WebSocket.PerMessageDeflate,
                  zlib_controlling_process: :erlang.pid_to_list(parent)}
               ]
             ) do
```