### PR TITLE
Handle unexpected continuation frames

### DIFF
--- a/lib/mint/web_socket/frame.ex
+++ b/lib/mint/web_socket/frame.ex
@@ -431,7 +431,7 @@ defmodule Mint.WebSocket.Frame do
     {:close, code, reason}
   end
 
-  def translate({:continuation, _, _, _, _}) do
+  def translate(continuation()) do
     {:error, :unexpected_continuation}
   end
 

--- a/lib/mint/web_socket/frame.ex
+++ b/lib/mint/web_socket/frame.ex
@@ -431,6 +431,10 @@ defmodule Mint.WebSocket.Frame do
     {:close, code, reason}
   end
 
+  def translate({:continuation, _, _, _, _}) do
+    {:error, :unexpected_continuation}
+  end
+
   @doc """
   Emits frames for any finalized fragments and stores any unfinalized fragments
   in the `:fragment` key in the websocket data structure

--- a/test/mint/web_socket/frame_test.exs
+++ b/test/mint/web_socket/frame_test.exs
@@ -9,4 +9,9 @@ defmodule Mint.WebSocket.FrameTest do
 
     assert ping(fin?: true) |> is_fin()
   end
+
+  test "incomplete frames should return error" do
+    assert {:error, :unexpected_continuation} =
+             translate({:continuation, <<0x0::size(3)>>, nil, "hello", true})
+  end
 end


### PR DESCRIPTION
As described in #32, an unexpected continuation frame will lead to a function clause error.  This patch adds an additional `translate/1` clause to match the unexpected frame and return an error tuple: `{:error, :unexpected_continuation}`.  Included test with the failure case.